### PR TITLE
Add R16B01 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}. %, fail_on_warning]}.
 
-{require_otp_vsn, "R1[4|5]B"}.
+{require_otp_vsn, "R1[4|5|6]B"}.
 
 {deps_dir, ["deps"]}.
 


### PR DESCRIPTION
R16B01 has been released (At least on my archlinux), and it runs will on this application. So I add R16B01 support in rebar.config.
